### PR TITLE
Add a tested watchlist item helper

### DIFF
--- a/src/watchlist.mjs
+++ b/src/watchlist.mjs
@@ -1,0 +1,12 @@
+export function createWatchlistItem(title) {
+  const normalizedTitle = title.trim()
+
+  if (!normalizedTitle) {
+    throw new TypeError('A title is required')
+  }
+
+  return {
+    title: normalizedTitle,
+    watched: false,
+  }
+}

--- a/test/watchlist.test.mjs
+++ b/test/watchlist.test.mjs
@@ -1,0 +1,18 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { createWatchlistItem } from '../src/watchlist.mjs'
+
+test('creates an unwatched item with a normalized title', () => {
+  assert.deepEqual(createWatchlistItem('  Arrival  '), {
+    title: 'Arrival',
+    watched: false,
+  })
+})
+
+test('rejects an empty title', () => {
+  assert.throws(() => createWatchlistItem('   '), {
+    name: 'TypeError',
+    message: 'A title is required',
+  })
+})


### PR DESCRIPTION
## What changed

- added `createWatchlistItem` to normalize titles and create unwatched items
- added Node.js tests for valid and empty titles

## Why

This is a small, isolated change used to verify that Codex can create a branch, publish code, and open a pull request through the connected GitHub integration.

## Impact

No existing files or behavior are modified.

## Validation

- `node --test test/watchlist.test.mjs`
- 2 tests passed